### PR TITLE
Add ArrowRight icon import to article page

### DIFF
--- a/app/makaleler/[slug]/page.tsx
+++ b/app/makaleler/[slug]/page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft, Calendar, Clock, Tag, Share2 } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Calendar, Clock, Tag, Share2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';


### PR DESCRIPTION
## Summary
- include ArrowRight icon in article page's lucide-react import to support forward navigation

## Testing
- `npm run build` *(fails: Failed to fetch Google fonts)*
- `npm run lint` *(fails: react/no-unescaped-entities errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68934f8647b08327b86d02ee295a22b6