### PR TITLE
Fix next-themes type import and mark as external

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
-import { type ThemeProviderProps } from "next-themes/dist/types"
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes"
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,13 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: { unoptimized: true },
+  webpack: (config) => {
+    config.externals = config.externals || [];
+    if (!config.externals.includes('next-themes')) {
+      config.externals.push('next-themes');
+    }
+    return config;
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- fix ThemeProvider import for next-themes types
- mark next-themes as an external in webpack config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch font `Fira Code` and `Orbitron`)*

------
https://chatgpt.com/codex/tasks/task_e_68935260c36883279c7b2b34e5567109